### PR TITLE
Check if output filename was passed to the CLI - fixes #11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,12 @@ const getInputfilePath = (targets, shouldThrow = false) => {
     return path.resolve(process.env.PWD, targets[0]);
 }
 
+// Sanity check: make sure that the value was passed to the `output` option
+// Fixes https://github.com/technopagan/sqip/issues/11
+const getOutputFilePath = () => {
+  const index = process.argv.findIndex(arg => arg == '-o' || arg == '--output');
+  return index > 0 ? process.argv[index + 1] : null;
+}
 
 //#############################################################################
 //# FUNCTIONS TOOLBELT
@@ -153,8 +159,10 @@ module.exports.run = () => {
     const { targets, options } = getArguments();
     const filename = getInputfilePath(targets);
     const { final_svg, svg_base64encoded, img_dimensions } = main(filename, options);
-    options.output ?
-        writeSVGOutput(options.output, final_svg) :
+    const output = getOutputFilePath();
+
+    output ?
+        writeSVGOutput(output, final_svg) :
         printFinalResult(img_dimensions, filename, svg_base64encoded);
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ const getInputfilePath = (targets, shouldThrow = false) => {
 // Sanity check: make sure that the value was passed to the `output` option
 // Fixes https://github.com/technopagan/sqip/issues/11
 const getOutputFilePath = () => {
-  const index = process.argv.findIndex(arg => arg == '-o' || arg == '--output');
+  const index = process.argv.findIndex(arg => arg === '-o' || arg === '--output');
   return index > 0 ? process.argv[index + 1] : null;
 }
 


### PR DESCRIPTION
This PR is a fix for #11. It seems like the issue is caused by a bug in the `argv` library that interprets the presence of the `-o` option as `true` and then converts it to a string. Here we check if a user has actually passed any value to the option and if so, write the output to the file. If the value (or the option itself) is absent, write the output to `stdout`.