### PR TITLE
Fix filename input for special character and spaces

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ const findLargerImageDimension = ({ width, height }) => width > height ? width :
 
 // Run Primitive with reasonable defaults (rectangles as shapes, 9 shaper per default) to generate the placeholder SVG
 const runPrimitive = (filename, { numberOfPrimitives = 8, mode = 0 }, primitive_output, dimensions) => {
-    child_process.execSync(`${primitiveExecutable} -i ${filename} -o ${primitive_output} -n ${numberOfPrimitives} -m ${mode} -s ${findLargerImageDimension(dimensions)}`);
+    child_process.execSync(`${primitiveExecutable} -i "${filename}" -o ${primitive_output} -n ${numberOfPrimitives} -m ${mode} -s ${findLargerImageDimension(dimensions)}`);
 }
 
 // Read the Primitive-generated SVG so that we can continue working on it


### PR DESCRIPTION
I played around with sqip and it looks awesome. I stumbled upon an exception that was thrown because I have images in my dropbox which has the following file path `~/Dropbox (Personal)/BG-IMAGES` and lead to an exception.

```
sqip -o aaron.svg -n 150 -m 0 -b 12 aaron-barnaby-454278.jpg                      [23:37:17]
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `/Users/stefanjudis/.nvm/versions/node/v9.4.0/lib/node_modules/sqip/vendor/primitive-darwin-x64 -i /Users/stefanjudis/Dropbox (Personal)/BG-IMAGES/aaron-barnaby-454278.jpg -o /var/folders/69/chkjm0116y77pcz855v672pr0000gn/T/primitive_tempfile.svg -n 150 -m 0 -s 6480'
child_process.js:614
    throw err;
    ^

Error: Command failed: /Users/stefanjudis/.nvm/versions/node/v9.4.0/lib/node_modules/sqip/vendor/primitive-darwin-x64 -i /Users/stefanjudis/Dropbox (Personal)/BG-IMAGES/aaron-barnaby-454278.jpg -o /var/folders/69/chkjm0116y77pcz855v672pr0000gn/T/primitive_tempfile.svg -n 150 -m 0 -s 6480
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `/Users/stefanjudis/.nvm/versions/node/v9.4.0/lib/node_modules/sqip/vendor/primitive-darwin-x64 -i /Users/stefanjudis/Dropbox (Personal)/BG-IMAGES/aaron-barnaby-454278.jpg -o /var/folders/69/chkjm0116y77pcz855v672pr0000gn/T/primitive_tempfile.svg -n 150 -m 0 -s 6480'
```

This PR quotes the input file path so that it's not throwing anymore. :)