### PR TITLE
fix(vendor): make primitive-win32-x64 executable

### DIFF
--- a/scripts/bundle-vendor.js
+++ b/scripts/bundle-vendor.js
@@ -14,7 +14,7 @@ const builds = [
   {
     os: "windows",
     arch: "amd64",
-    filename: "primitive-win32-x64"
+    filename: "primitive-win32-x64.exe"
   }
 ];
 builds.forEach(build => {


### PR DESCRIPTION
Current build step produces non-executable file so this introduces the following error on runtime: 

```
primitive-win32-x64 is not recognized as an internal or external command,operable program or batch file.
```

Making it executable does the job, tested on Windows 7 x64 SP1 & Windows 10, version 1709.
