### PR TITLE
Fix error when there are spaces in the filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,13 @@ const findLargerImageDimension = ({ width, height }) => width > height ? width :
 
 // Run Primitive with reasonable defaults (rectangles as shapes, 9 shaper per default) to generate the placeholder SVG
 const runPrimitive = (filename, { numberOfPrimitives = 8, mode = 0 }, primitive_output, dimensions) => {
-    child_process.execSync(`${primitiveExecutable} -i "${filename}" -o ${primitive_output} -n ${numberOfPrimitives} -m ${mode} -s ${findLargerImageDimension(dimensions)}`);
+    child_process.execFileSync(primitiveExecutable, [
+        "-i", filename,
+        "-o", primitive_output,
+        "-n", numberOfPrimitives,
+        "-m", mode,
+        "-s", findLargerImageDimension(dimensions)
+    ]);
 }
 
 // Read the Primitive-generated SVG so that we can continue working on it


### PR DESCRIPTION
Hey, I had an issue where sqip would fail when trying to process filenames with spaces. I see that the input filename parameter is quoted, but somehow it's still failing for me, maybe it has something to do with the fact that I'm running this on WSL (Windows Subsystem for Linux).

So, I fixed the issue by using `child_process.execFileSync` instead `child_process.execSync`, which should avoid any similar issues entirely. That's because `execSync` passes the whole command string for the shell to parse, but `execFileSync` skips the shell and passes the list of arguments to the executed command directly.