### PR TITLE
Refactor: svg group fix and blur

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,9 @@
 module.exports = {
-  extends: ['prettier-standard']
+  parserOptions: { ecmaVersion: 2018 },
+  plugins: ['node'],
+  extends: ['prettier-standard', 'plugin:node/recommended'],
+  rules: {
+    // As CLI tool, we want to take care of exit codes and error output on our own
+    'no-process-exit': 0
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,7 @@
     "precommit": "npm run lint",
     "prepush": "npm run test"
   },
-  "files": [
-    "src",
-    "vendor"
-  ],
+  "files": ["src", "vendor"],
   "keywords": [
     "lqip",
     "svg",
@@ -38,6 +35,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
+    "cheerio": "^1.0.0-rc.2",
     "image-size": "^0.6.1",
     "svgo": "^0.7.2",
     "yargs": "^11.0.0"
@@ -52,7 +50,6 @@
     "url": "https://who.tobias.is/"
   },
   "devDependencies": {
-    "cheerio": "^1.0.0-rc.2",
     "codecov": "^3.0.0",
     "eslint": "^4.19.0",
     "eslint-config-prettier": "^2.9.0",
@@ -70,8 +67,6 @@
     "prettier": "^1.11.1"
   },
   "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.js"
-    ]
+    "collectCoverageFrom": ["src/**/*.js"]
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,5 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
+
 const yargs = require('yargs')
 
 const sqip = require('./index.js')

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const {
   printFinalResult
 } = require('./utils/helpers')
 const { checkForPrimitive, runPrimitive } = require('./utils/primitive')
-const { runSVGO, replaceSVGAttrs } = require('./utils/svg')
+const { runSVGO, prepareSVG, applyBlurFilter } = require('./utils/svg')
 
 module.exports = options => {
   // Build configuration based on passed options and default options
@@ -61,12 +61,6 @@ module.exports = options => {
     numberOfPrimitives,
     mode
   }
-  const svgOptions = Object.assign(
-    {
-      blur: config.blur
-    },
-    imgDimensions
-  )
 
   // Run primitive
   const primitiveOutput = runPrimitive(
@@ -74,11 +68,15 @@ module.exports = options => {
     primitiveOptions,
     imgDimensions
   )
-  // Optimize SVG
-  const svgoOutput = runSVGO(primitiveOutput)
 
-  // Patch SVG group and apply blur filter if needed
-  const finalSvg = replaceSVGAttrs(svgoOutput, svgOptions)
+  // Prepare SVG
+  const preparedSVG = prepareSVG(primitiveOutput, imgDimensions)
+
+  // Apply blur filter
+  const blurredSVG = applyBlurFilter(preparedSVG, { blur: config.blur })
+
+  // Optimize SVG
+  const finalSvg = runSVGO(blurredSVG)
 
   // Encode SVG
   const svgBase64Encoded = encodeBase64(finalSvg)

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -39,7 +39,7 @@ describe('cli api', () => {
         expect($('svg')).toHaveLength(1)
 
         // Check default blur value
-        const $filter = $('svg filter#b feGaussianBlur')
+        const $filter = $('svg > filter > feGaussianBlur')
         expect($filter).toHaveLength(1)
         expect($filter.attr('stdDeviation')).toBe('12')
 
@@ -110,7 +110,7 @@ describe('cli api', () => {
         const $ = cheerio.load(content, { xml: true })
 
         // Check blur to be given value (5)
-        const $filter = $('svg filter#b feGaussianBlur')
+        const $filter = $('svg > filter > feGaussianBlur')
         expect($filter).toHaveLength(1)
         expect($filter.attr('stdDeviation')).toBe('5')
       })

--- a/test/unit/__snapshots__/index.test.js.snap
+++ b/test/unit/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`node api no config passed 1`] = `"Please provide an input image, e.g. s
 
 exports[`node api resolves valid input path 1`] = `
 Object {
-  "finalSvg": "fixedSVGResult",
+  "finalSvg": "svgoResult",
   "imgDimensions": Object {
     "height": 768,
     "width": 1024,

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -13,7 +13,8 @@ jest.mock('../../src/utils/primitive.js', () => ({
 
 jest.mock('../../src/utils/svg.js', () => ({
   runSVGO: jest.fn(() => 'svgoResult'),
-  replaceSVGAttrs: jest.fn(() => 'fixedSVGResult')
+  prepareSVG: jest.fn(() => 'preparedSVGResult'),
+  applyBlurFilter: jest.fn(() => 'blurredSVGResult')
 }))
 
 describe('node api', () => {

--- a/test/unit/utils/__snapshots__/svg.test.js.snap
+++ b/test/unit/utils/__snapshots__/svg.test.js.snap
@@ -1,11 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`replaceSVGAttrs svg with group, config with dimensions and zero blur 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 1024 640\\"><path fill=\\"#bada55\\" d=\\"M0 0h1024v640H0z\\"/><g><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"`;
+exports[`applies blur filter do nothing when no blur is given 1`] = `"<svg viewBox=\\"0 0 1024 768\\"><rect fill=\\"#bada55\\"/><g><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"`;
 
-exports[`replaceSVGAttrs svg with group, config with dimensions only 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 1024 640\\"><filter id=\\"b\\"><feGaussianBlur stdDeviation=\\"12\\" /></filter><path fill=\\"#bada55\\" d=\\"M0 0h1024v640H0z\\"/><g filter=\\"url(#b)\\"><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"`;
+exports[`applies blur filter svg with group and blur 1`] = `"<svg viewBox=\\"0 0 1024 768\\"><filter id=\\"b\\"><feGaussianBlur stdDeviation=\\"5\\"/></filter><rect fill=\\"#bada55\\"/><g filter=\\"url(#b)\\"><g><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></g></svg>"`;
 
-exports[`replaceSVGAttrs svg with group, config with dimensions only and blur 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 1024 640\\"><filter id=\\"b\\"><feGaussianBlur stdDeviation=\\"5\\" /></filter><path fill=\\"#bada55\\" d=\\"M0 0h1024v640H0z\\"/><g filter=\\"url(#b)\\"><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"`;
+exports[`applies blur filter svg without group and blur 1`] = `"<svg viewBox=\\"0 0 1024 768\\"><filter id=\\"b\\"><feGaussianBlur stdDeviation=\\"5\\"/></filter><rect fill=\\"#bada55\\"/><g filter=\\"url(#b)\\"><polygon points=\\"0,100 50,25 50,75 100,0\\"/></g></svg>"`;
 
-exports[`replaceSVGAttrs svg with group, no config 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 undefined undefined\\"><filter id=\\"b\\"><feGaussianBlur stdDeviation=\\"12\\" /></filter><path fill=\\"#bada55\\" d=\\"M0 0h1024v640H0z\\"/><g filter=\\"url(#b)\\"><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"`;
+exports[`does prepare svg properly svg with group, with config 1`] = `"<svg viewBox=\\"0 0 1024 768\\"><rect fill=\\"#bada55\\" width=\\"100%\\" height=\\"100%\\"/><g><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"`;
 
-exports[`replaceSVGAttrs svg without group, config with dimensions only 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 1024 640\\"><filter id=\\"c\\"><feGaussianBlur stdDeviation=\\"55\\" /></filter><path fill=\\"#bada55\\" d=\\"M0 0h1024v640H0z\\"/><g filter='url(#c)' fill-opacity='.5'><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"`;
+exports[`does prepare svg properly svg with missing background 1`] = `
+"The SVG must have a rect as first shape element which represents the svg background color:
+
+<svg viewBox=\\"0 0 1024 768\\"><path fill=\\"#bada55\\" d=\\"M0 0h1024v640H0z\\"/><g><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"
+`;
+
+exports[`does prepare svg properly svg without group, config with dimensions only 1`] = `"<svg viewBox=\\"0 0 1024 768\\"><rect fill=\\"#bada55\\" width=\\"100%\\" height=\\"100%\\"/><polygon points=\\"0,100 50,25 50,75 100,0\\"/></svg>"`;
+
+exports[`does prepare svg properly svg without viewport, given width & height 1`] = `"<svg viewBox=\\"0 0 1024 640\\"><rect fill=\\"#bada55\\" width=\\"100%\\" height=\\"100%\\"/><g><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"`;
+
+exports[`does prepare svg properly svg without viewport, not given width & height 1`] = `
+"SVG is missing viewBox attribute while Width and height were not passed:
+
+<svg><rect fill=\\"#bada55\\"/><g><path fill=\\"#C0FFEE\\" d=\\"M51.5 17.5l4 18 15 1z\\"/></g></svg>"
+`;


### PR DESCRIPTION
This is my first attempt to change the inner code logic of sqip on the road to a plugin based system (See #30)

It does the following:

* Split up svg fix and group + blur injection. Basically making blur the first "plugin" (Still lacking plugin conf ofc)
* Replace the regex group injection with cheerio which should be way more flexible. This may allow using non-primitive svgs for the plugins later on.